### PR TITLE
Melhorias em flag-feature

### DIFF
--- a/app/BFS.hs
+++ b/app/BFS.hs
@@ -3,6 +3,7 @@ module BFS where
 import Node (Node(..), bomba)
 import Node (Coord)
 import Grid (Grid, check, updateGrid, insertFlag, removeFlag)
+import Control.Concurrent (threadDelay)
 
 bfs :: Grid -> Int -> Coord -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
 bfs grid size (i, j) cnt win flag = bfsRec grid [(i, j)] size cnt win flag
@@ -27,7 +28,7 @@ bfsRec grid ((i, j):queue) size cnt win flag
             newCnt = if not (visited node) then cnt + 1 else cnt
         threadDelay 5000
         bfsRec newGrid queue size newCnt win False
-    else do
+    | otherwise = do
         let newGrid = updateGrid grid i j
             newCnt = if not (visited node) then cnt + 1 else cnt
         let expandedQueue = expandQueue newGrid size (i, j) queue
@@ -39,43 +40,3 @@ expandQueue :: Grid -> Int -> Coord -> [Coord] -> [Coord]
 expandQueue grid size (x, y) queue = foldl (\q (dx, dy) -> if check grid size (x + dx, y + dy) && not (visited (grid !! (x + dx) !! (y + dy))) then q ++ [(x + dx, y + dy)] else q) queue dxy
   where dxy = [(-1, 0), (0, 1), (1, 0), (0, -1)]
 
-
-
--- Função principal DFS
-dfs :: Grid -> Int -> Coord -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
-dfs grid size (i, j) cnt win flag = dfsRec grid [(i, j)] size cnt win flag
-
--- Função recursiva para o DFS
-dfsRec :: Grid -> [Coord] -> Int -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
-dfsRec grid [] _ cnt _ _ = return (True, cnt, grid)  -- Se a pilha está vazia, acabou
-dfsRec grid ((i, j):stack) size cnt win flag
-    | flag == True && not (visited node) = do
-        let gridWithFlag = showFlag grid i j
-        dfsRec gridWithFlag stack size cnt win True
-    | dataNode node == bomba = return (False, cnt, grid)  -- Bomba, perdeu
-    | cnt == win = return (True, cnt, grid)  -- Se o contador atingir a quantidade total de células visitáveis, ganhou
-    | visited node = dfsRec grid stack size cnt win False  -- Se o nó já foi visitado, segue para o próximo
-    | dataNode node /= 0 = do  -- Se for número, não visita mais nada
-        let newGrid = updateGrid grid i j
-            newCnt = if not (visited node) then cnt + 1 else cnt
-        threadDelay 5000
-        dfsRec newGrid stack size newCnt win False
-    | otherwise = do
-        let newGrid = updateGrid grid i j
-            newCnt = if not (visited node) then cnt + 1 else cnt
-        let expandedStack = expandStack newGrid size (i, j) stack
-        dfsRec newGrid expandedStack size newCnt win False
-  where
-    node = grid !! i !! j  -- Obtém o nó correspondente à coordenada (i, j)
-
--- Expande a pilha (LIFO)
-expandStack :: Grid -> Int -> Coord -> [Coord] -> [Coord]
-expandStack grid size (x, y) stack = 
-    foldr (\(dx, dy) acc -> 
-        let newCoord = (x + dx, y + dy)
-        in if check grid size newCoord && not (visited (grid !! (x + dx) !! (y + dy)))
-           then newCoord : acc
-           else acc
-    ) stack dxy
-  where
-    dxy = [(-1, 0), (0, 1), (1, 0), (0, -1)]  -- Movimentos para expandir (cima, direita, baixo, esquerda)

--- a/app/BFS.hs
+++ b/app/BFS.hs
@@ -11,12 +11,14 @@ bfsRec :: Grid -> [Coord] -> Int -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
 bfsRec grid [] _ cnt _ _ = return (True, cnt, grid)  -- Se a fila está vazia, acabou
 bfsRec grid ((i, j):queue) size cnt win flag
     | flag && not (visited node) = do
-        if not (hasFlag node) then do
+        if not (hasFlag node) then do  -- Insere nova bandeira
             let gridWithNewFlag = insertFlag grid i j
             bfsRec gridWithNewFlag queue size cnt win True
-        else do
+        else do                        -- Remove a bandeira
             let gridWithOneLessFlag = removeFlag grid i j
             bfsRec gridWithOneLessFlag queue size cnt win False
+    | not flag && (hasFlag node) = do  -- Caso clique onde há bandeira, não faz nada
+        bfsRec grid queue size cnt win False
     | dataNode node == bomba = return (False, cnt, grid)  -- Bomba, perdeu
     | cnt == win = return (True, cnt, grid)  -- Se o contador atingir a quantidade total de células visitáveis, ganhou
     | visited node = bfsRec grid queue size cnt win False  -- Se o nó já foi visitado, segue pro prox

--- a/app/BFS.hs
+++ b/app/BFS.hs
@@ -2,7 +2,7 @@ module BFS where
 
 import Node (Node(..), bomba)
 import Node (Coord)
-import Grid (Grid, check, updateGrid, showFlag)
+import Grid (Grid, check, updateGrid, insertFlag, removeFlag)
 
 bfs :: Grid -> Int -> Coord -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
 bfs grid size (i, j) cnt win flag = bfsRec grid [(i, j)] size cnt win flag
@@ -10,9 +10,13 @@ bfs grid size (i, j) cnt win flag = bfsRec grid [(i, j)] size cnt win flag
 bfsRec :: Grid -> [Coord] -> Int -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
 bfsRec grid [] _ cnt _ _ = return (True, cnt, grid)  -- Se a fila está vazia, acabou
 bfsRec grid ((i, j):queue) size cnt win flag
-    | flag == True && not (visited node) = do
-        let gridWithFlag = showFlag grid i j
-        bfsRec gridWithFlag queue size cnt win True
+    | flag && not (visited node) = do
+        if not (hasFlag node) then do
+            let gridWithNewFlag = insertFlag grid i j
+            bfsRec gridWithNewFlag queue size cnt win True
+        else do
+            let gridWithOneLessFlag = removeFlag grid i j
+            bfsRec gridWithOneLessFlag queue size cnt win False
     | dataNode node == bomba = return (False, cnt, grid)  -- Bomba, perdeu
     | cnt == win = return (True, cnt, grid)  -- Se o contador atingir a quantidade total de células visitáveis, ganhou
     | visited node = bfsRec grid queue size cnt win False  -- Se o nó já foi visitado, segue pro prox

--- a/app/DFS.hs
+++ b/app/DFS.hs
@@ -1,0 +1,53 @@
+module DFS where
+
+import Node (Node(..), bomba)
+import Node (Coord)
+import Grid (Grid, check, updateGrid, insertFlag, removeFlag)
+import Control.Concurrent (threadDelay)
+
+
+-- Função principal DFS
+dfs :: Grid -> Int -> Coord -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
+dfs grid size (i, j) cnt win flag = dfsRec grid [(i, j)] size cnt win flag
+
+-- Função recursiva para o DFS
+dfsRec :: Grid -> [Coord] -> Int -> Int -> Int -> Bool -> IO (Bool, Int, Grid)
+dfsRec grid [] _ cnt _ _ = return (True, cnt, grid)  -- Se a pilha está vazia, acabou
+dfsRec grid ((i, j):stack) size cnt win flag
+    | flag && not (visited node) = do
+        if not (hasFlag node) then do  -- Insere nova bandeira
+            let gridWithNewFlag = insertFlag grid i j
+            dfsRec gridWithNewFlag stack size cnt win True
+        else do                        -- Remove a bandeira
+            let gridWithOneLessFlag = removeFlag grid i j
+            dfsRec gridWithOneLessFlag stack size cnt win False
+    | not flag && (hasFlag node) = do  -- Caso clique onde há bandeira, não faz nada
+        dfsRec grid stack size cnt win False
+    | dataNode node == bomba = return (False, cnt, grid)  -- Bomba, perdeu
+    | cnt == win = return (True, cnt, grid)  -- Se o contador atingir a quantidade total de células visitáveis, ganhou
+    | visited node = dfsRec grid stack size cnt win False  -- Se o nó já foi visitado, segue para o próximo
+    | dataNode node /= 0 = do  -- Se for número, não visita mais nada
+        let newGrid = updateGrid grid i j
+            newCnt = if not (visited node) then cnt + 1 else cnt
+        threadDelay 5000
+        dfsRec newGrid stack size newCnt win False
+    | otherwise = do
+        let newGrid = updateGrid grid i j
+            newCnt = if not (visited node) then cnt + 1 else cnt
+        let expandedStack = expandStack newGrid size (i, j) stack
+        dfsRec newGrid expandedStack size newCnt win False
+  where
+    node = grid !! i !! j  -- Obtém o nó correspondente à coordenada (i, j)
+
+-- Expande a pilha (LIFO)
+expandStack :: Grid -> Int -> Coord -> [Coord] -> [Coord]
+expandStack grid size (x, y) stack = 
+    foldr (\(dx, dy) acc -> 
+        let newCoord = (x + dx, y + dy)
+        in if check grid size newCoord && not (visited (grid !! (x + dx) !! (y + dy)))
+           then newCoord : acc
+           else acc
+    ) stack dxy
+  where
+    dxy = [(-1, 0), (0, 1), (1, 0), (0, -1)]  -- Movimentos para expandir (cima, direita, baixo, esquerda)
+

--- a/app/Game.hs
+++ b/app/Game.hs
@@ -19,7 +19,8 @@ module Game
     ) where
 
 import Grid (generateGrid, revealBombs, Grid)
-import BFS (bfs, dfs)
+import BFS (bfs)
+import DFS (dfs)
 import Node (Node(..), bomba)
 import Data.Time.Clock (UTCTime, getCurrentTime, diffUTCTime)
 

--- a/app/Grid.hs
+++ b/app/Grid.hs
@@ -64,11 +64,19 @@ updateGrid grid i j =
     in ys ++ ((xs ++ (newNode : xs')) : zs')
 
 -- Atualiza o estado do nó marcando que há uma bandeira
-showFlag :: Grid -> Int -> Int -> Grid
-showFlag grid i j = 
+insertFlag :: Grid -> Int -> Int -> Grid
+insertFlag grid i j = 
     let (ys, zs:zs') = splitAt i grid
         (xs, node:xs') = splitAt j zs
         newNode = node { hasFlag = True }
+    in ys ++ ((xs ++ (newNode : xs')) : zs')
+
+-- Atualiza o estado do nó retirando a sinalização de que há bandeira
+removeFlag :: Grid -> Int -> Int -> Grid
+removeFlag grid i j = 
+    let (ys, zs:zs') = splitAt i grid
+        (xs, node:xs') = splitAt j zs
+        newNode = node { hasFlag = False }
     in ys ++ ((xs ++ (newNode : xs')) : zs')
 
 -- Função para revelar bombas quando perde

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,7 +23,22 @@ import Raylib.Types (Rectangle (Rectangle, rectangle'height, rectangle'width), p
 import Raylib.Util (drawing, whileWindowOpen_, withWindow, managed)
 import Raylib.Util.Colors (black, white)
 
-import Game (gameInit, gameUpdate, state'grid, state'cnt, state'finished, state'win, state'lose, state'size, state'remainingBombs,state'startTime, state'currentTime, state'structureType, printGrid, gameRestart)
+import Game 
+  ( gameInit 
+  , gameUpdate
+  , state'grid
+  , state'cnt
+  , state'finished
+  , state'win
+  , state'lose
+  , state'size
+  , state'remainingBombs
+  , state'startTime
+  , state'currentTime
+  , state'structureType
+  , printGrid
+  , gameRestart
+  )
 import Node (Node(..), bomba)
 import Grid (Grid)
 import GHC.Generics (S)


### PR DESCRIPTION
Melhorias feitas:

- agora é possível tanto inserir quanto remover uma bandeira (clicar com botão direito do mouse em cima da célula para fazer ambos)
- agora clicar normalmente em uma célula com bandeira nada acontece, apenas após remover a bandeira (antes a presença da bandeira não impedia um clique na célula)